### PR TITLE
ReflectionScanner uses ClassLoader of current thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ target/**
 *.mymetadata
 *.project
 **/*.project
+.idea/
+*.iml
+target/

--- a/scanner/reflections/src/main/java/de/devsurf/injection/guice/scanner/reflections/ReflectionsScanner.java
+++ b/scanner/reflections/src/main/java/de/devsurf/injection/guice/scanner/reflections/ReflectionsScanner.java
@@ -163,7 +163,7 @@ public class ReflectionsScanner implements ClasspathScanner {
 
 			Class<Object> objectClass;
 			try {
-				objectClass = (Class<Object>) Class.forName(classFile.getName());
+				objectClass = (Class<Object>) Class.forName(classFile.getName(), true, Thread.currentThread().getContextClassLoader());
 			} catch (ClassNotFoundException e) {
 				ReflectionsScanner.this._logger.log(Level.WARNING,
 					"Failure while trying to load the Class \"" + classFile.getName()


### PR DESCRIPTION
`ReflectionsScanner` now employs the `ClassLoader` used by `StartupModule`, so classes found by the module can be loaded by the scanner even if module and scanner were loaded with different `ClassLoader`s.
