### PR TITLE
ASM AnnotationCollector uses the parent thread's context classloader.

### DIFF
--- a/scanner/asm/src/main/java/de/devsurf/injection/guice/scanner/asm/AnnotationCollector.java
+++ b/scanner/asm/src/main/java/de/devsurf/injection/guice/scanner/asm/AnnotationCollector.java
@@ -118,7 +118,7 @@ public class AnnotationCollector implements ClassVisitor {
 		String annotationClassStr = sig.replace('/', '.').substring(1, sig.length() - 1);
 		if (_class == null) {
 			try {
-				_class = getClass().getClassLoader().loadClass(_name);
+				_class = Thread.currentThread().getContextClassLoader().loadClass(_name);
 			} catch (ClassNotFoundException e) {
 				_logger.log(Level.WARNING,
 					"Failure while visitAnnotation. Class could not be loaded.", e);


### PR DESCRIPTION
That way, it should be able to load all classes discovered by the StartupModule.

Note that there seems to be a threading problem in the ASM scanner: Sometimes it picked up my module twice  - but never when I had breakpoints enabled to reproduce the problem. I doubt this is connected to the change, though.
